### PR TITLE
Fix gamepad state getting messed up in firefox

### DIFF
--- a/nano-ide.js
+++ b/nano-ide.js
@@ -1089,7 +1089,7 @@ function submitFrame() {
         }
 
         // Update old state
-        prevRealGamepadState[player] = realGamepad;
+        if (realGamepad) { prevRealGamepadState[player] = realGamepad; }
     }
 
     // Reset the just-pressed state


### PR DESCRIPTION
Firefox doesn't seem to pick up the gamepad right away, so the code to
update the old gamepad state populates the array with undefineds. Then in
a later frame, the gamepad appears and the code attempts to use the invalid
previous state array.

This change ensures the previous state array is only updated if we have valid
gamepad input.