### PR TITLE
fixed Array.sort(...) for Chromium based browsers

### DIFF
--- a/nano-ide.js
+++ b/nano-ide.js
@@ -61,7 +61,7 @@ if(τ>31)cls(clr=0);i=j=x=v=∅
 var initialSource =
     //tests.forwith;
     //tests.customSprite;
-    tests.customRotate;
+    //tests.customRotate;
     //tests.debug;
     //tests.textstyle;
     //tests.starattack;
@@ -87,7 +87,7 @@ var initialSource =
     //tests.plasma2;
     //tests.manySprites;
     //tests.FCN;
-    //tests.sort;
+    tests.sort;
     //tests.ping;
     //tests.IF;
     //tests.keyrepeat;

--- a/nano-runtime.js
+++ b/nano-runtime.js
@@ -69,14 +69,14 @@ function _arraySort(k) {
         if (typeof this[0] === 'object') {
             // find the first property, alphabetically
             var entries = Object.entries(this[0]);
-            entries.sort(function(a, b) { return a[0] > b[0]; });
+            entries.sort(function(a, b) { return a[0]-b[0]; });
             k = entries[0][0];
-            compare = function (a, b) { return a[k] > b[k]; };
+            compare = function (a, b) { return a[k]-b[k]; };
         } else {
-            compare = _greaterThan;
+            compare = function (a, b) {return a-b};
         }
     } else {
-        compare = function (a, b) { return a[k] > b[k]; };
+        compare = function (a, b) { return a[k]-b[k]; };
     }
 
     this.sort(compare);

--- a/nano-tests.js
+++ b/nano-tests.js
@@ -177,7 +177,15 @@ text(f)`,
 a=[1,10,3,5,2]
 a.sort()
 for i<a.len
- text(a[i],32,6i+2,1)`,
+ text(a[i],16,6i+2,1)
+o=[{y:2,x:2,a:2,t:"b"},{y:1,x:1,a:1,t:"a"},{y:3,x:3,a:3,t:"c"}]
+o.sort()
+for i<o.len
+ text(o[i].a,32,6i+2,1)
+o.sort("x")
+for i<o.len
+ text(o[i].x,48,6i+2,1)
+`,
     
     hash: `#nanojam hash,1
 for(i<64)line(i,64hash(⅒(i+τ)),i,64,1)`,


### PR DESCRIPTION
comparison functions apparently shouldn't just return a boolean but any of [-1, 0, 1], since Chrome and FF have slightly different behaviors, Chrome just converts the returned boolean into an integer value, true => 1, false =>0, and since 0 means equal sorting did not work in Chromium based browsers. This patch should fix that.

tested in Chrome, Brave and Firefox

Nice work btw, I'd be sad to see this cute little thing dying